### PR TITLE
Fix merger duplicate ids

### DIFF
--- a/src/game/conflict_detector.py
+++ b/src/game/conflict_detector.py
@@ -55,6 +55,11 @@ def run_conflict_detector(universe_id: str):
     for conflict in conflicts:
         # ---- DEBUG START ----
         print(f"[conflict_detector] 🔍 Detected conflict: {conflict}")
+
+        # Deduplicate any repeated game IDs
+        game_ids = conflict.get("game_ids", [])
+        conflict["game_ids"] = list(dict.fromkeys(game_ids))
+
         try:
             universe_db.record_conflict(universe_id, conflict)
             print(f"[conflict_detector] ✅ Recorded conflict to DB for universe {universe_id}")

--- a/src/game/merger.py
+++ b/src/game/merger.py
@@ -15,8 +15,12 @@ def run_merger_for_conflict(universe_id: str, conflict_info: dict):
     Merge the game instances in conflict_info['game_ids'] into a new single game.
     """
     from_ids = conflict_info.get("game_ids", [])
+
+    # Deduplicate IDs to avoid merging a game with itself
+    from_ids = list(dict.fromkeys(from_ids))
+
     if len(from_ids) < 2:
-        # nothing to merge
+        # nothing to merge after removing duplicates
         return
 
     # 1) Build a merged game name from the existing ones

--- a/src/server/main.py
+++ b/src/server/main.py
@@ -110,7 +110,7 @@ async def start_periodic_news_loop():
                 try:
                     run_news_extractor(uni["id"])
                 except Exception as e:
-                    logging.error(f"Error in scheduled news for {uni["id"]}: {e}")
+                    logging.error(f"Error in scheduled news for {uni['id']}: {e}")
             await asyncio.sleep(30 * 60)
 
     asyncio.create_task(news_loop())


### PR DESCRIPTION
## Summary
- avoid merging the same game instance with itself by deduplicating ids
- ensure conflict detector stores unique ids
- fix syntax error in error logging string

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'itsdangerous', ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_686aad8ddbb48324a12ef737a84d0911