### PR TITLE
Ensure merged games include previous summaries

### DIFF
--- a/src/db/game_db.py
+++ b/src/db/game_db.py
@@ -193,3 +193,18 @@ def update_game_status(game_id: str, status: str):
         raise
     finally:
         conn.close()
+
+def get_latest_game_summary(game_id: str) -> Optional[str]:
+    """Return the latest summary text for the given game, if any."""
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT summary FROM game_history "
+                "WHERE game_id = %s ORDER BY summary_date DESC LIMIT 1",
+                (game_id,),
+            )
+            row = cur.fetchone()
+            return row[0] if row else None
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary
- add helper `get_latest_game_summary` to fetch last summary for a game
- include `save_chat_message` and `get_latest_game_summary` in merger
- when merging games, prepend summaries from each source game as a system message

## Testing
- `pip install itsdangerous`
- `pytest -q` *(fails: ProxyError downloading models)*

------
https://chatgpt.com/codex/tasks/task_e_686ab0bc83088324a9ba1e2f1180248c