### PR TITLE
Fix message serialization for closed games

### DIFF
--- a/src/server/game.py
+++ b/src/server/game.py
@@ -192,7 +192,15 @@ def list_game_messages(game_id: str, request: Request):
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
     try:
         msgs = game_db.list_chat_messages(game_id)
-        return {"messages": msgs}
+        serialized = [
+            {
+                "sender": msg["sender"],
+                "message": msg["message"],
+                "timestamp": msg["timestamp"].isoformat() + "Z",
+            }
+            for msg in msgs
+        ]
+        return {"messages": serialized}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- fix `/api/game/{id}/messages` to serialize timestamps as strings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'itsdangerous' and connection errors)*

------
https://chatgpt.com/codex/tasks/task_e_686abbd475008324a1e66685f372120a