### PR TITLE
Improve entity extractor handling of known characters

### DIFF
--- a/src/prompt_templates/entity_extractor_system.txt
+++ b/src/prompt_templates/entity_extractor_system.txt
@@ -4,5 +4,11 @@ Determine whether each is a player-controlled character (each player owns only o
 Return a JSON object matching this schema:
 {schema}
 
+Known player characters and owned objects:
+{known_entities}
+
+Treat any occurrence of these names as referring to the canonical entity.
+Do not change their `player_character` flag if it is already set to true.
+
 Conversation:
 {conversation}


### PR DESCRIPTION
## Summary
- allow passing known entities to the named entity extractor
- include known player characters list in entity extractor prompt
- fetch joined characters in game_chat and send them to the extractor

## Testing
- `pip install -q -r requirements.txt`
- `pip install -q itsdangerous`
- `pytest -q` *(fails: ProxyError and ConnectionError)*

------
https://chatgpt.com/codex/tasks/task_e_686d4f9bae54832488dd7dcc26b07994