### PR TITLE
Add universes browsing page

### DIFF
--- a/src/server/main.py
+++ b/src/server/main.py
@@ -272,3 +272,14 @@ def read_universe_create(request: Request):
     return templates.TemplateResponse(
         "universe_create.html", {"request": request}
     )
+
+
+@app.get("/universes", response_class=HTMLResponse)
+def read_universes_page(request: Request):
+    username = request.session.get("username")
+    if not username:
+        return RedirectResponse(url="/", status_code=302)
+    return templates.TemplateResponse(
+        "universes.html",
+        {"request": request}
+    )

--- a/src/server/static/css/universes.css
+++ b/src/server/static/css/universes.css
@@ -1,0 +1,25 @@
+.universe-layout {
+  display: flex;
+  gap: 1rem;
+}
+.universe-list-panel {
+  width: 20%;
+  min-width: 150px;
+}
+.universe-diagram-panel {
+  flex: 1;
+}
+#universe-list {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0 0 0;
+  max-height: 80vh;
+  overflow-y: auto;
+}
+#universe-list li {
+  padding: 0.25rem;
+  cursor: pointer;
+}
+#universe-list li:hover {
+  background: #eee;
+}

--- a/src/server/static/js/universes.jsx
+++ b/src/server/static/js/universes.jsx
@@ -1,0 +1,57 @@
+// src/server/static/js/universes.jsx
+
+async function loadUniverses() {
+  const list = document.getElementById('universe-list');
+  list.innerHTML = '';
+  try {
+    const resp = await fetch('/api/universe/list');
+    if (!resp.ok) throw new Error();
+    const universes = await resp.json();
+    universes.forEach(u => {
+      const li = document.createElement('li');
+      li.textContent = u.name;
+      li.dataset.id = u.id;
+      li.addEventListener('click', () => selectUniverse(u));
+      list.appendChild(li);
+    });
+  } catch (e) {
+    list.innerHTML = '<li>Error loading universes</li>';
+  }
+}
+
+function filterUniverses() {
+  const term = document.getElementById('universe-search').value.toLowerCase();
+  document.querySelectorAll('#universe-list li').forEach(li => {
+    li.style.display = li.textContent.toLowerCase().includes(term) ? '' : 'none';
+  });
+}
+
+function selectUniverse(universe) {
+  drawPlaceholder(universe.name);
+}
+
+function drawPlaceholder(name) {
+  const svg = d3.select('#sankey-diagram');
+  const width = parseInt(svg.style('width')) || 600;
+  const height = parseInt(svg.attr('height')) || 400;
+  svg.selectAll('*').remove();
+  const colors = ['#4e79a7', '#f28e2b', '#e15759', '#76b7b2'];
+  for (let i = 0; i < 3; i++) {
+    svg.append('rect')
+      .attr('x', (i + 0.25) * width / 3)
+      .attr('y', 0)
+      .attr('width', width / 6)
+      .attr('height', height)
+      .attr('fill', colors[i % colors.length])
+      .attr('opacity', 0.7);
+  }
+  svg.append('text')
+    .attr('x', 10)
+    .attr('y', 20)
+    .text(`Sankey placeholder for ${name}`);
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadUniverses();
+  document.getElementById('universe-search').addEventListener('input', filterUniverses);
+});

--- a/src/server/templates/lobby.html
+++ b/src/server/templates/lobby.html
@@ -38,6 +38,12 @@
       <a href="/universe/new" class="btn-link">Go to Universe Creation &rarr;</a>
     </section>
 
+    <!-- Browse Universes -->
+    <section id="browse-universes-link">
+      <h3>Browse Universes</h3>
+      <a href="/universes" class="btn-link">View Universes &rarr;</a>
+    </section>
+
     <!-- Create Character -->
     <section id="create-character-link">
       <h3>Create New Character</h3>

--- a/src/server/templates/universes.html
+++ b/src/server/templates/universes.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+
+{% block title %}Universes - Influence RPG{% endblock %}
+
+{% block css %}
+  <link rel="stylesheet" href="{{ url_for('static', path=asset_path('universes.css')) }}">
+{% endblock %}
+
+{% block content %}
+<div class="universe-layout">
+  <div class="universe-list-panel">
+    <input type="text" id="universe-search" placeholder="Search universes" />
+    <ul id="universe-list"></ul>
+  </div>
+  <div class="universe-diagram-panel">
+    <svg id="sankey-diagram" width="100%" height="600"></svg>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+  <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <script type="module" src="{{ url_for('static', path=asset_path('universes.jsx')) }}"></script>
+{% endblock %}

--- a/vite.config.js
+++ b/vite.config.js
@@ -31,6 +31,7 @@ export default defineConfig({
         'lobby': resolve(__dirname, 'src/server/static/js/lobby.jsx'),
         'login': resolve(__dirname, 'src/server/static/js/login.js'),
         'universe_create': resolve(__dirname, 'src/server/static/js/universe_create.js'),
+        'universes': resolve(__dirname, 'src/server/static/js/universes.jsx'),
 
         // CSS entries
         'style': resolve(__dirname, 'src/server/static/css/style.css'),
@@ -38,6 +39,7 @@ export default defineConfig({
         'game_creation_css': resolve(__dirname, 'src/server/static/css/game_creation.css'),
         'lobby_css': resolve(__dirname, 'src/server/static/css/lobby.css'),
         'login_css': resolve(__dirname, 'src/server/static/css/login.css'),
+        'universes_css': resolve(__dirname, 'src/server/static/css/universes.css'),
       },
       output: {
         // Place all assets under 'assets/' with content hashes


### PR DESCRIPTION
## Summary
- scaffold Universes page with placeholder Sankey diagram
- add styles and script for new page
- link from lobby
- expose /universes route
- register new assets with Vite

## Testing
- `npm install`
- `npm run build:static`
- `pytest -q` *(fails: OSError Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68701fb2681c8324b5c0e1dba7c0315d