### PR TITLE
Implement universe Sankey diagram

### DIFF
--- a/src/db/universe_db.py
+++ b/src/db/universe_db.py
@@ -105,6 +105,25 @@ def list_universes_for_game(game_id: str) -> list[str]:
     finally:
         conn.close()
 
+def list_games_in_universe(universe_id: str) -> list[dict]:
+    """Return games linked to the given universe."""
+    conn = get_db_connection()
+    try:
+        with conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT g.id, g.name, g.status, g.created_at
+                  FROM games g
+                  JOIN universe_games ug ON g.id = ug.game_id
+                 WHERE ug.universe_id = %s
+                 ORDER BY g.created_at
+                """,
+                (universe_id,)
+            )
+            return cur.fetchall()
+    finally:
+        conn.close()
+
 def record_event(universe_id: str, game_id: str, event_type: str, event_payload: dict):
     """
     Insert a new event into the universe_events table.

--- a/src/server/static/js/universes.jsx
+++ b/src/server/static/js/universes.jsx
@@ -26,8 +26,21 @@ function filterUniverses() {
   });
 }
 
-function selectUniverse(universe) {
-  drawPlaceholder(universe.name);
+async function selectUniverse(universe) {
+  const svg = d3.select('#sankey-diagram');
+  svg.selectAll('*').remove();
+  try {
+    const [eventsResp, gamesResp] = await Promise.all([
+      fetch(`/api/universe/${universe.id}/events`),
+      fetch(`/api/universe/${universe.id}/games`)
+    ]);
+    if (!eventsResp.ok || !gamesResp.ok) throw new Error();
+    const events = await eventsResp.json();
+    const games = await gamesResp.json();
+    drawSankey(universe.name, games, events);
+  } catch (e) {
+    drawPlaceholder(universe.name);
+  }
 }
 
 function drawPlaceholder(name) {
@@ -49,6 +62,102 @@ function drawPlaceholder(name) {
     .attr('x', 10)
     .attr('y', 20)
     .text(`Sankey placeholder for ${name}`);
+}
+
+function drawSankey(name, games, events) {
+  const svg = d3.select('#sankey-diagram');
+  const width = parseInt(svg.style('width')) || 600;
+  const height = parseInt(svg.attr('height')) || 400;
+  svg.selectAll('*').remove();
+
+  const nodes = [];
+  const links = [];
+  const nodeById = new Map();
+
+  games.forEach(g => {
+    const node = {
+      id: g.id,
+      name: g.name,
+      time: new Date(g.created_at)
+    };
+    nodes.push(node);
+    nodeById.set(g.id, node);
+  });
+
+  events.forEach(ev => {
+    if (ev.event_type === 'branched_from') {
+      const child = nodeById.get(ev.game_id);
+      if (child) child.time = new Date(ev.event_time);
+      const parent = nodeById.get(ev.event_payload.original_game_id);
+      if (parent && child) {
+        links.push({ source: parent.id, target: child.id, value: 1 });
+      }
+    } else if (ev.event_type === 'merger') {
+      const target = nodeById.get(ev.game_id);
+      if (target) target.time = new Date(ev.event_time);
+      const fromIds = ev.event_payload.from_instance_ids || [];
+      fromIds.forEach(src => {
+        if (nodeById.has(src) && target) {
+          links.push({ source: src, target: target.id, value: 1 });
+        }
+      });
+    }
+  });
+
+  const times = Array.from(new Set(nodes.map(n => n.time.getTime())))
+    .sort((a, b) => a - b)
+    .map(t => new Date(t));
+  const timeIndex = new Map(times.map((t, i) => [t.getTime(), i]));
+
+  const sankeyGen = d3.sankey()
+    .nodeId(d => d.id)
+    .nodeWidth(15)
+    .nodePadding(10)
+    .nodeAlign(d => timeIndex.get(d.time.getTime()))
+    .extent([[0, 0], [width, height]]);
+
+  const graph = sankeyGen({ nodes: nodes.map(d => Object.assign({}, d)), links });
+
+  const scale = d3.scaleTime()
+    .domain(d3.extent(times))
+    .range([0, width - sankeyGen.nodeWidth()]);
+
+  graph.nodes.forEach(n => {
+    const x = scale(n.time);
+    n.x0 = x;
+    n.x1 = x + sankeyGen.nodeWidth();
+  });
+
+  svg.append('g')
+    .selectAll('path')
+    .data(graph.links)
+    .join('path')
+    .attr('d', d3.sankeyLinkHorizontal())
+    .attr('fill', 'none')
+    .attr('stroke', '#888')
+    .attr('stroke-width', d => Math.max(1, d.width))
+    .attr('opacity', 0.6);
+
+  svg.append('g')
+    .selectAll('rect')
+    .data(graph.nodes)
+    .join('rect')
+    .attr('x', d => d.x0)
+    .attr('y', d => d.y0)
+    .attr('width', d => d.x1 - d.x0)
+    .attr('height', d => d.y1 - d.y0)
+    .attr('fill', '#4e79a7')
+    .attr('opacity', 0.8);
+
+  svg.append('g')
+    .selectAll('text')
+    .data(graph.nodes)
+    .join('text')
+    .attr('x', d => d.x0 + 5)
+    .attr('y', d => (d.y0 + d.y1) / 2)
+    .attr('dy', '0.35em')
+    .text(d => d.name)
+    .style('font-size', '10px');
 }
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/src/server/templates/universes.html
+++ b/src/server/templates/universes.html
@@ -20,5 +20,6 @@
 
 {% block scripts %}
   <script src="https://cdn.jsdelivr.net/npm/d3@7"></script>
+  <script src="https://cdn.jsdelivr.net/npm/d3-sankey@0.12"></script>
   <script type="module" src="{{ url_for('static', path=asset_path('universes.jsx')) }}"></script>
 {% endblock %}

--- a/src/server/universe.py
+++ b/src/server/universe.py
@@ -30,6 +30,19 @@ class ConflictResponse(BaseModel):
     conflict_info: dict
     detected_at: datetime
 
+class EventResponse(BaseModel):
+    id: int
+    game_id: str
+    event_type: str
+    event_payload: dict
+    event_time: datetime
+
+class GameBrief(BaseModel):
+    id: str
+    name: str
+    status: str
+    created_at: datetime
+
 @router.post("/universe/create", response_model=UniverseResponse)
 def create_universe_endpoint(req: UniverseCreateRequest):
     try:
@@ -75,3 +88,22 @@ def list_universe_conflicts(universe_id: str):
         return universe_db.list_conflicts(universe_id)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/universe/{universe_id}/events", response_model=List[EventResponse])
+def list_universe_events(universe_id: str, limit: int = 100):
+    """Return recent universe events for diagramming."""
+    try:
+        return universe_db.list_events(universe_id, limit=limit)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/universe/{universe_id}/games", response_model=List[GameBrief])
+def list_universe_games(universe_id: str):
+    """List games linked to a universe."""
+    try:
+        return universe_db.list_games_in_universe(universe_id)
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+


### PR DESCRIPTION
## Summary
- provide DB helper to list games in a universe
- expose /api endpoints to fetch universe games and events
- load data on universe selection and render a basic D3 Sankey diagram
- include d3-sankey on universes page

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: itsdangerous)*

------
https://chatgpt.com/codex/tasks/task_e_68702c0e87d4832482781d78c6fc7a98