### PR TITLE
Handle GM chain-of-thought broadcast

### DIFF
--- a/src/test/test_branch.py
+++ b/src/test/test_branch.py
@@ -137,6 +137,7 @@ def test_websocket_branch(monkeypatch):
     client = TestClient(app)
     with client.websocket_connect("/ws/game/base/chat?username=u&character_id=c1") as ws:
         ws.send_text("/gm branch {}")
+        _thought = ws.receive_text()
         data = ws.receive_text()
         assert "Game branched" in data
         ws.send_text("hello")


### PR DESCRIPTION
## Summary
- broadcast intermediate GM output as `GM chain-of-thought`
- finalize GM message only when no tools are called
- update websocket branch test for chain-of-thought behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874123a7c1c8324acb264ec574d445c