### PR TITLE
Fix long chat message rendering

### DIFF
--- a/src/server/static/css/style.css
+++ b/src/server/static/css/style.css
@@ -40,6 +40,9 @@ button {
 
 .message {
   margin-bottom: 10px;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  word-break: break-word;
 }
 
 .timestamp {


### PR DESCRIPTION
## Summary
- wrap chat log messages to prevent overflow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6877f69b6f64832497b00a29e2f92273