### PR TITLE
Add new conversation feature

### DIFF
--- a/src/db/user_db.py
+++ b/src/db/user_db.py
@@ -42,6 +42,17 @@ def verify_user_password(username: str, password: str) -> bool:
         conn.close()
 
 
+def user_exists(username: str) -> bool:
+    """Return True if a user with the given username exists."""
+    conn = get_db_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute("SELECT 1 FROM users WHERE username = %s", (username,))
+            return cur.fetchone() is not None
+    finally:
+        conn.close()
+
+
 def update_password(username: str, new_password: str) -> None:
     """Update the user's password hash."""
     conn = get_db_connection()

--- a/src/server/messages.py
+++ b/src/server/messages.py
@@ -6,6 +6,7 @@ import uuid
 from datetime import datetime
 
 from src.server.main import templates
+from src.db import user_db
 
 router = APIRouter()
 
@@ -89,6 +90,8 @@ def send_message(data: SendMessageRequest, request: Request):
     username = request.session.get("username")
     if not username:
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated")
+    if not user_db.user_exists(data.recipient):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Recipient does not exist")
     _messages.append({
         "id": str(uuid.uuid4()),
         "sender": username,

--- a/src/server/static/js/messages.jsx
+++ b/src/server/static/js/messages.jsx
@@ -4,6 +4,10 @@ document.addEventListener('DOMContentLoaded', () => {
   const messageList = document.getElementById('message-list');
   const msgInput = document.getElementById('message-input');
   const sendBtn = document.getElementById('send-message-button');
+  const newRecipient = document.getElementById('new-recipient');
+  const newMessage = document.getElementById('new-message');
+  const startBtn = document.getElementById('start-convo-button');
+  const newError = document.getElementById('new-convo-error');
   const withUser = withUserInput ? withUserInput.value : '';
 
   async function loadMessages(user) {
@@ -56,6 +60,31 @@ document.addEventListener('DOMContentLoaded', () => {
         loadMessages(withUser);
       } catch (err) {
         console.error('Error sending message:', err);
+      }
+    });
+  }
+
+  if (startBtn) {
+    startBtn.addEventListener('click', async () => {
+      const recipient = newRecipient.value.trim();
+      const text = newMessage.value.trim();
+      if (!recipient || !text) return;
+      newError.textContent = '';
+      try {
+        const resp = await fetch('/api/messages/send', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ recipient, message: text })
+        });
+        if (resp.ok) {
+          window.location.href = `/messages?user=${encodeURIComponent(recipient)}`;
+        } else {
+          const data = await resp.json().catch(() => null);
+          newError.textContent = (data && data.detail) || 'Error sending message';
+        }
+      } catch (err) {
+        console.error('Error sending message:', err);
+        newError.textContent = 'Error sending message';
       }
     });
   }

--- a/src/server/templates/messages.html
+++ b/src/server/templates/messages.html
@@ -22,6 +22,13 @@
         <p>No conversations yet.</p>
       {% endif %}
     </div>
+    <div id="new-conversation">
+      <h3>Start New Conversation</h3>
+      <input type="text" id="new-recipient" placeholder="Username" />
+      <input type="text" id="new-message" placeholder="Your message" />
+      <button id="start-convo-button">Send</button>
+      <div id="new-convo-error" class="error"></div>
+    </div>
     <div id="message-thread">
       {% if with_user %}
         <h3>Conversation with {{ with_user }}</h3>


### PR DESCRIPTION
## Summary
- enable checking if a user exists in user_db
- validate recipient in messages API
- allow creating new conversations from messages page
- add client-side handlers to start a new conversation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c0ff1eda8832497613b89332cb83e