### PR TITLE
Enable dice tool in character creation wizard

### DIFF
--- a/src/prompt_templates/character_wizard_system.txt
+++ b/src/prompt_templates/character_wizard_system.txt
@@ -2,6 +2,10 @@ You are a character-creation assistant. Your job is to ask the user one question
 
 When all required fields have been collected, output **only** the final JSON object with – name: the character’s name string – all other fields under character_data as a sub-object.
 
+If you need random values from dice, output a JSON object like:
+{{"tool_calls": {{"dice": {{"num_rolls": N, "sides": M}}}}, "narrative": "reason"}}
+The server will provide the results before you continue.
+
 --- RULESET BEGIN ---
 {ruleset_text}
 --- RULESET END ---

--- a/src/test/test_character_wizard.py
+++ b/src/test/test_character_wizard.py
@@ -1,0 +1,34 @@
+import json
+from fastapi.testclient import TestClient
+from src.server.main import app
+
+
+def test_character_wizard_dice(monkeypatch):
+    from src.server import character_wizard as cw
+
+    def fake_get_ruleset(rid):
+        return {"id": rid, "char_creation": "rules"}
+
+    calls = {"step": 0}
+
+    def fake_generate(prompt, conversation_context="", max_retries=3):
+        if calls["step"] == 0:
+            calls["step"] = 1
+            return json.dumps({
+                "tool_calls": {"dice": {"num_rolls": 2, "sides": 6}},
+                "narrative": "rolling"
+            })
+        else:
+            assert "Dice results" in prompt
+            return json.dumps({"name": "Hero", "character_data": {"str": 10}})
+
+    monkeypatch.setattr(cw, "get_ruleset", fake_get_ruleset)
+    monkeypatch.setattr(cw, "generate_completion", fake_generate)
+
+    client = TestClient(app)
+    resp = client.post("/api/character/wizard", json={"ruleset_id": "r1", "history": []})
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["complete"] is True
+    assert data["name"] == "Hero"
+    assert data["character_data"]["str"] == 10


### PR DESCRIPTION
## Summary
- allow the character wizard LLM to request dice rolls
- update wizard prompt instructions for dice tool
- loop in character_wizard API to handle tool calls
- add test for dice functionality

## Testing
- `pip install -q itsdangerous`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68813efeb8e08324be1b5be75c30ee65