### PR TITLE
Add finalize editing step to character creation wizard

### DIFF
--- a/src/server/static/js/character_wizard.jsx
+++ b/src/server/static/js/character_wizard.jsx
@@ -9,6 +9,8 @@ export default function CharacterWizard({ username }) {
   const [history, setHistory] = useState([]);
   const [question, setQuestion] = useState('');
   const [answer, setAnswer] = useState('');
+  const [finalData, setFinalData] = useState(null); // {name, character_data}
+  const [editData, setEditData] = useState({});
 
   // Fetch universes on mount
   useEffect(() => {
@@ -49,28 +51,36 @@ export default function CharacterWizard({ username }) {
       .then(res => res.json())
       .then(resp => {
         if (resp.complete) {
-          // Final character_data
-          return fetch('/character/create', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-              username,
-              universe_id: selectedUni,
-              name: resp.name,
-              character_data: resp.character_data
-            })
-          });
+          setFinalData({ name: resp.name, character_data: resp.character_data });
+          setEditData({ name: resp.name, ...resp.character_data });
+          setPhase('finalize');
         } else {
           setQuestion(resp.question);
           setAnswer('');
         }
       })
-      .then(res => {
-        if (res && res.ok) {
-          // Redirect to lobby
-          window.location.href = `/lobby?username=${encodeURIComponent(username)}`;
-        }
+      .catch(console.error);
+  };
+
+  const discardChanges = () => {
+    if (finalData) {
+      setEditData({ name: finalData.name, ...finalData.character_data });
+    }
+  };
+
+  const saveCharacter = () => {
+    const { name, ...charData } = editData;
+    fetch('/character/create', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        username,
+        universe_id: selectedUni,
+        name,
+        character_data: charData
       })
+    })
+      .then(res => { if (res.ok) window.location.href = `/lobby?username=${encodeURIComponent(username)}`; })
       .catch(console.error);
   };
 
@@ -110,6 +120,32 @@ export default function CharacterWizard({ username }) {
             disabled={!answer}
             onClick={submitAnswer}
           >Submit Answer</button>
+        </div>
+      )}
+
+      {phase === 'finalize' && (
+        <div>
+          <h2 className="text-xl font-bold mb-4">Finalize Your Character</h2>
+          <table className="w-full border mb-4">
+            <tbody>
+              {Object.entries(editData).map(([k, v]) => (
+                <tr key={k}>
+                  <td className="border px-2 py-1 font-semibold">{k}</td>
+                  <td className="border px-2 py-1">
+                    <input
+                      className="w-full border p-1 rounded"
+                      value={v}
+                      onChange={e => setEditData({ ...editData, [k]: e.target.value })}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <div className="flex justify-between">
+            <button className="bg-gray-500 text-white p-2 rounded" onClick={discardChanges}>Discard Changes</button>
+            <button className="bg-green-600 text-white p-2 rounded" onClick={saveCharacter}>Save Character</button>
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- extend the `character_wizard.jsx` React component with a new `finalize` phase
- allow edits to generated character data before saving
- provide buttons to discard or save changes

## Testing
- `npm run build:static`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6881441b74dc832496a685426566c281